### PR TITLE
String support

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -12,16 +12,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="2be96c61-a869-49e1-a6f0-06fa04b9dd52" name="Default Changelist" comment="">
-      <change afterPath="$PROJECT_DIR$/src/Object.cpp" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/h/Object.h" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/CMakeLists.txt" beforeDir="false" afterPath="$PROJECT_DIR$/CMakeLists.txt" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/Compiler.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Compiler.cpp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/VM.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/VM.cpp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/Value.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Value.cpp" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/h/Compiler.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Compiler.h" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/h/VM.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/VM.h" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/h/Value.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Value.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Scanner.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Scanner.cpp" afterDir="false" />
     </list>
     <ignored path="$PROJECT_DIR$/cmake-build-debug/" />
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
@@ -47,7 +39,7 @@
       </usages-collector>
       <usages-collector id="statistics.file.extensions.edit">
         <counts>
-          <entry key="cpp" value="16442" />
+          <entry key="cpp" value="16691" />
           <entry key="h" value="10373" />
           <entry key="mm" value="24" />
           <entry key="txt" value="104" />
@@ -56,14 +48,15 @@
       <usages-collector id="statistics.file.types.edit">
         <counts>
           <entry key="CMakeLists.txt" value="104" />
-          <entry key="ObjectiveC" value="26839" />
+          <entry key="ObjectiveC" value="27088" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.extensions.open">
         <counts>
-          <entry key="cpp" value="20" />
+          <entry key="cpp" value="21" />
           <entry key="h" value="31" />
           <entry key="matilda (disassembly)" value="2" />
+          <entry key="md" value="1" />
           <entry key="txt" value="1" />
         </counts>
       </usages-collector>
@@ -71,7 +64,8 @@
         <counts>
           <entry key="CMakeLists.txt" value="1" />
           <entry key="Disassembly" value="2" />
-          <entry key="ObjectiveC" value="51" />
+          <entry key="ObjectiveC" value="52" />
+          <entry key="PLAIN_TEXT" value="1" />
         </counts>
       </usages-collector>
     </session>
@@ -90,11 +84,11 @@
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="true">
+      <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="89">
-              <caret line="103" column="52" selection-start-line="103" selection-start-column="52" selection-end-line="103" selection-end-column="52" />
+            <state relative-caret-position="1124">
+              <caret line="93" column="29" selection-start-line="93" selection-start-column="29" selection-end-line="93" selection-end-column="29" />
               <folding>
                 <element signature="e#0#23#0" expanded="true" />
               </folding>
@@ -102,10 +96,29 @@
           </provider>
         </entry>
       </file>
+      <file pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/src/Scanner.cpp">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="359">
+              <caret line="82" lean-forward="true" selection-start-line="82" selection-end-line="82" />
+              <folding>
+                <element signature="e#0#18#0" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/CODE_OF_CONDUCT.md">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="-666" />
+          </provider>
+        </entry>
+      </file>
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/VM.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="1515">
+            <state relative-caret-position="795">
               <caret line="101" column="13" selection-start-line="101" selection-start-column="13" selection-end-line="101" selection-end-column="13" />
             </state>
           </provider>
@@ -115,7 +128,7 @@
         <entry file="file://$PROJECT_DIR$/src/Value.cpp">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="255">
-              <caret line="17" column="23" lean-forward="true" selection-start-line="17" selection-start-column="23" selection-end-line="17" selection-end-column="23" />
+              <caret line="17" column="23" selection-start-line="17" selection-start-column="23" selection-end-line="17" selection-end-column="23" />
             </state>
           </provider>
         </entry>
@@ -136,7 +149,7 @@
         <entry file="file://$PROJECT_DIR$/src/h/VM.h">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="254">
-              <caret line="25" lean-forward="true" selection-start-line="25" selection-end-line="25" />
+              <caret line="25" selection-start-line="25" selection-end-line="25" />
               <folding>
                 <element signature="e#35#53#0" expanded="true" />
               </folding>
@@ -148,28 +161,7 @@
         <entry file="file://$PROJECT_DIR$/src/Object.cpp">
           <provider selected="true" editor-type-id="text-editor">
             <state relative-caret-position="345">
-              <caret line="23" lean-forward="true" selection-start-line="23" selection-end-line="23" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/Object.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="240">
-              <caret line="16" column="35" lean-forward="true" selection-start-line="16" selection-start-column="35" selection-end-line="16" selection-end-column="35" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/Matilda.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state>
-              <caret column="2" selection-start-column="2" selection-end-column="2" />
-              <folding>
-                <element signature="e#83#100#0" expanded="true" />
-              </folding>
+              <caret line="23" selection-start-line="23" selection-end-line="23" />
             </state>
           </provider>
         </entry>
@@ -211,7 +203,6 @@
         <option value="$PROJECT_DIR$/CMakeLists.txt" />
         <option value="$PROJECT_DIR$/src/h/Token.h" />
         <option value="$PROJECT_DIR$/src/h/Scanner.h" />
-        <option value="$PROJECT_DIR$/src/Scanner.cpp" />
         <option value="$PROJECT_DIR$/src/h/Matilda.h" />
         <option value="$PROJECT_DIR$/src/h/Chunk.h" />
         <option value="$PROJECT_DIR$/src/Matilda.cpp" />
@@ -225,6 +216,7 @@
         <option value="$PROJECT_DIR$/src/h/VM.h" />
         <option value="$PROJECT_DIR$/src/VM.cpp" />
         <option value="$PROJECT_DIR$/src/Compiler.cpp" />
+        <option value="$PROJECT_DIR$/src/Scanner.cpp" />
       </list>
     </option>
   </component>
@@ -328,12 +320,12 @@
       <workItem from="1542066890604" duration="59000" />
       <workItem from="1542147155070" duration="22000" />
       <workItem from="1542409758464" duration="13767000" />
-      <workItem from="1542501359149" duration="6587000" />
+      <workItem from="1542501359149" duration="7743000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="61758000" />
+    <option name="totallyTimeSpent" value="62914000" />
   </component>
   <component name="ToolWindowManager">
     <frame x="67" y="25" width="1853" height="1055" extended-state="6" />
@@ -439,16 +431,6 @@
     <entry file="file://$PROJECT_DIR$/src/h/common.h">
       <provider selected="true" editor-type-id="text-editor" />
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/Scanner.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="2220">
-          <caret line="148" selection-start-line="148" selection-end-line="148" />
-          <folding>
-            <element signature="e#0#18#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file:///usr/include/c++/7/ext/new_allocator.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="843">
@@ -490,7 +472,7 @@
     <entry file="file://$PROJECT_DIR$/src/h/Object.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="240">
-          <caret line="16" column="35" lean-forward="true" selection-start-line="16" selection-start-column="35" selection-end-line="16" selection-end-column="35" />
+          <caret line="16" column="35" selection-start-line="16" selection-start-column="35" selection-end-line="16" selection-end-column="35" />
         </state>
       </provider>
     </entry>
@@ -507,7 +489,7 @@
     <entry file="file://$PROJECT_DIR$/src/Object.cpp">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="345">
-          <caret line="23" lean-forward="true" selection-start-line="23" selection-end-line="23" />
+          <caret line="23" selection-start-line="23" selection-end-line="23" />
         </state>
       </provider>
     </entry>
@@ -524,7 +506,7 @@
     <entry file="file://$PROJECT_DIR$/src/h/VM.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="254">
-          <caret line="25" lean-forward="true" selection-start-line="25" selection-end-line="25" />
+          <caret line="25" selection-start-line="25" selection-end-line="25" />
           <folding>
             <element signature="e#35#53#0" expanded="true" />
           </folding>
@@ -544,7 +526,7 @@
     <entry file="file://$PROJECT_DIR$/src/Value.cpp">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="255">
-          <caret line="17" column="23" lean-forward="true" selection-start-line="17" selection-start-column="23" selection-end-line="17" selection-end-column="23" />
+          <caret line="17" column="23" selection-start-line="17" selection-start-column="23" selection-end-line="17" selection-end-column="23" />
         </state>
       </provider>
     </entry>
@@ -555,19 +537,34 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/CODE_OF_CONDUCT.md">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-666" />
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/VM.cpp">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1515">
+        <state relative-caret-position="795">
           <caret line="101" column="13" selection-start-line="101" selection-start-column="13" selection-end-line="101" selection-end-column="13" />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="89">
-          <caret line="103" column="52" selection-start-line="103" selection-start-column="52" selection-end-line="103" selection-end-column="52" />
+        <state relative-caret-position="1124">
+          <caret line="93" column="29" selection-start-line="93" selection-start-column="29" selection-end-line="93" selection-end-column="29" />
           <folding>
             <element signature="e#0#23#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Scanner.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="359">
+          <caret line="82" lean-forward="true" selection-start-line="82" selection-end-line="82" />
+          <folding>
+            <element signature="e#0#18#0" expanded="true" />
           </folding>
         </state>
       </provider>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -12,8 +12,15 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="2be96c61-a869-49e1-a6f0-06fa04b9dd52" name="Default Changelist" comment="">
+      <change afterPath="$PROJECT_DIR$/src/Object.cpp" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/h/Object.h" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/Chunk.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Chunk.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/CMakeLists.txt" beforeDir="false" afterPath="$PROJECT_DIR$/CMakeLists.txt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Compiler.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Compiler.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/VM.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/VM.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Value.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Value.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/Compiler.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Compiler.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/VM.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/VM.h" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/h/Value.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Value.h" afterDir="false" />
     </list>
     <ignored path="$PROJECT_DIR$/cmake-build-debug/" />
@@ -28,20 +35,20 @@
     <session id="-622551910">
       <usages-collector id="statistics.lifecycle.project">
         <counts>
-          <entry key="project.closed" value="7" />
-          <entry key="project.open.time.1" value="3" />
+          <entry key="project.closed" value="8" />
+          <entry key="project.open.time.1" value="4" />
           <entry key="project.open.time.10" value="1" />
           <entry key="project.open.time.6" value="1" />
           <entry key="project.open.time.7" value="1" />
           <entry key="project.open.time.8" value="2" />
           <entry key="project.open.time.9" value="1" />
-          <entry key="project.opened" value="9" />
+          <entry key="project.opened" value="10" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.extensions.edit">
         <counts>
-          <entry key="cpp" value="14794" />
-          <entry key="h" value="9391" />
+          <entry key="cpp" value="16442" />
+          <entry key="h" value="10373" />
           <entry key="mm" value="24" />
           <entry key="txt" value="104" />
         </counts>
@@ -49,13 +56,13 @@
       <usages-collector id="statistics.file.types.edit">
         <counts>
           <entry key="CMakeLists.txt" value="104" />
-          <entry key="ObjectiveC" value="24209" />
+          <entry key="ObjectiveC" value="26839" />
         </counts>
       </usages-collector>
       <usages-collector id="statistics.file.extensions.open">
         <counts>
-          <entry key="cpp" value="18" />
-          <entry key="h" value="28" />
+          <entry key="cpp" value="20" />
+          <entry key="h" value="31" />
           <entry key="matilda (disassembly)" value="2" />
           <entry key="txt" value="1" />
         </counts>
@@ -64,7 +71,7 @@
         <counts>
           <entry key="CMakeLists.txt" value="1" />
           <entry key="Disassembly" value="2" />
-          <entry key="ObjectiveC" value="46" />
+          <entry key="ObjectiveC" value="51" />
         </counts>
       </usages-collector>
     </session>
@@ -74,8 +81,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/h/Compiler.h">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="269">
-              <caret line="91" column="84" selection-start-line="91" selection-start-column="84" selection-end-line="91" selection-end-column="84" />
+            <state relative-caret-position="-120">
+              <caret line="67" column="18" selection-start-line="67" selection-start-column="18" selection-end-line="67" selection-end-column="18" />
               <folding>
                 <element signature="e#55#71#0" expanded="true" />
               </folding>
@@ -83,11 +90,11 @@
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="false">
+      <file pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="114">
-              <caret line="89" selection-start-line="89" selection-end-line="89" />
+            <state relative-caret-position="89">
+              <caret line="103" column="52" selection-start-line="103" selection-start-column="52" selection-end-line="103" selection-end-column="52" />
               <folding>
                 <element signature="e#0#23#0" expanded="true" />
               </folding>
@@ -98,8 +105,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/VM.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="603">
-              <caret line="59" column="58" selection-start-line="59" selection-start-column="58" selection-end-line="59" selection-end-column="58" />
+            <state relative-caret-position="1515">
+              <caret line="101" column="13" selection-start-line="101" selection-start-column="13" selection-end-line="101" selection-end-column="13" />
             </state>
           </provider>
         </entry>
@@ -107,17 +114,20 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Value.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="540">
-              <caret line="36" column="46" selection-start-line="36" selection-start-column="46" selection-end-line="36" selection-end-column="46" />
+            <state relative-caret-position="255">
+              <caret line="17" column="23" lean-forward="true" selection-start-line="17" selection-start-column="23" selection-end-line="17" selection-end-column="23" />
             </state>
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="true">
+      <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/h/Value.h">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="419">
-              <caret line="41" column="4" selection-start-line="41" selection-start-column="4" selection-end-line="41" selection-end-column="4" />
+            <state relative-caret-position="390">
+              <caret line="47" column="42" selection-start-line="47" selection-start-column="42" selection-end-line="47" selection-end-column="42" />
+              <folding>
+                <element signature="e#49#68#0" expanded="true" />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -125,8 +135,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/h/VM.h">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="-1">
-              <caret line="8" column="28" selection-start-line="8" selection-start-column="28" selection-end-line="8" selection-end-column="28" />
+            <state relative-caret-position="254">
+              <caret line="25" lean-forward="true" selection-start-line="25" selection-end-line="25" />
               <folding>
                 <element signature="e#35#53#0" expanded="true" />
               </folding>
@@ -135,10 +145,28 @@
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Object.cpp">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="345">
+              <caret line="23" lean-forward="true" selection-start-line="23" selection-end-line="23" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/h/Object.h">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="240">
+              <caret line="16" column="35" lean-forward="true" selection-start-line="16" selection-start-column="35" selection-end-line="16" selection-end-column="35" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/h/Matilda.h">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="285">
-              <caret line="19" column="7" selection-start-line="19" selection-start-column="7" selection-end-line="19" selection-end-column="7" />
+            <state>
+              <caret column="2" selection-start-column="2" selection-end-column="2" />
               <folding>
                 <element signature="e#83#100#0" expanded="true" />
               </folding>
@@ -149,32 +177,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Chunk.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="1050">
-              <caret line="73" column="79" selection-start-line="73" selection-start-column="79" selection-end-line="73" selection-end-column="79" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/Matilda.cpp">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="225">
-              <caret line="15" selection-start-line="15" selection-end-line="15" />
-              <folding>
-                <element signature="e#0#18#0" expanded="true" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/Chunk.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="359">
-              <caret line="33" column="12" selection-start-line="33" selection-start-column="12" selection-end-line="33" selection-end-column="12" />
-              <folding>
-                <element signature="e#78#96#0" expanded="true" />
-              </folding>
+            <state relative-caret-position="-121">
+              <caret line="78" column="53" selection-start-line="78" selection-start-column="53" selection-end-line="78" selection-end-column="53" />
             </state>
           </provider>
         </entry>
@@ -197,7 +201,6 @@
       <list>
         <option value="$PROJECT_DIR$/src/Token.h" />
         <option value="$PROJECT_DIR$/src/main.cpp" />
-        <option value="$PROJECT_DIR$/src/Object.cpp" />
         <option value="$PROJECT_DIR$/h/Object.h" />
         <option value="$PROJECT_DIR$/h/Token.h" />
         <option value="$PROJECT_DIR$/h/Matilda.h" />
@@ -209,16 +212,19 @@
         <option value="$PROJECT_DIR$/src/h/Token.h" />
         <option value="$PROJECT_DIR$/src/h/Scanner.h" />
         <option value="$PROJECT_DIR$/src/Scanner.cpp" />
-        <option value="$PROJECT_DIR$/src/h/VM.h" />
         <option value="$PROJECT_DIR$/src/h/Matilda.h" />
-        <option value="$PROJECT_DIR$/src/h/Compiler.h" />
         <option value="$PROJECT_DIR$/src/h/Chunk.h" />
-        <option value="$PROJECT_DIR$/src/Compiler.cpp" />
-        <option value="$PROJECT_DIR$/src/Value.cpp" />
-        <option value="$PROJECT_DIR$/src/VM.cpp" />
         <option value="$PROJECT_DIR$/src/Matilda.cpp" />
         <option value="$PROJECT_DIR$/src/Chunk.cpp" />
+        <option value="$PROJECT_DIR$/src/h/Compiler.h" />
         <option value="$PROJECT_DIR$/src/h/Value.h" />
+        <option value="$PROJECT_DIR$/src/h/StringObject.h" />
+        <option value="$PROJECT_DIR$/src/h/Object.h" />
+        <option value="$PROJECT_DIR$/src/Object.cpp" />
+        <option value="$PROJECT_DIR$/src/Value.cpp" />
+        <option value="$PROJECT_DIR$/src/h/VM.h" />
+        <option value="$PROJECT_DIR$/src/VM.cpp" />
+        <option value="$PROJECT_DIR$/src/Compiler.cpp" />
       </list>
     </option>
   </component>
@@ -321,17 +327,18 @@
       <workItem from="1542063843974" duration="1726000" />
       <workItem from="1542066890604" duration="59000" />
       <workItem from="1542147155070" duration="22000" />
-      <workItem from="1542409758464" duration="12271000" />
+      <workItem from="1542409758464" duration="13767000" />
+      <workItem from="1542501359149" duration="6587000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="53675000" />
+    <option name="totallyTimeSpent" value="61758000" />
   </component>
   <component name="ToolWindowManager">
     <frame x="67" y="25" width="1853" height="1055" extended-state="6" />
     <layout>
-      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.10570005" />
+      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.10680686" />
       <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
       <window_info id="Favorites" order="2" side_tool="true" />
       <window_info anchor="bottom" id="Message" order="0" />
@@ -402,7 +409,6 @@
   </component>
   <component name="editorHistoryManager">
     <entry file="file://$PROJECT_DIR$/h/Object.h" />
-    <entry file="file://$PROJECT_DIR$/src/Object.cpp" />
     <entry file="file:///usr/include/c++/7/bits/stl_map.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="198">
@@ -459,89 +465,110 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/src/h/Chunk.h">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="359">
-          <caret line="33" column="12" selection-start-line="33" selection-start-column="12" selection-end-line="33" selection-end-column="12" />
+        <state relative-caret-position="315">
+          <caret line="21" column="8" selection-start-line="21" selection-start-column="8" selection-end-line="33" selection-end-column="12" />
           <folding>
             <element signature="e#78#96#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/Compiler.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="269">
-          <caret line="91" column="84" selection-start-line="91" selection-start-column="84" selection-end-line="91" selection-end-column="84" />
-          <folding>
-            <element signature="e#55#71#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="114">
-          <caret line="89" selection-start-line="89" selection-end-line="89" />
-          <folding>
-            <element signature="e#0#23#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/VM.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="603">
-          <caret line="59" column="58" selection-start-line="59" selection-start-column="58" selection-end-line="59" selection-end-column="58" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Value.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="540">
-          <caret line="36" column="46" selection-start-line="36" selection-start-column="46" selection-end-line="36" selection-end-column="46" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/Matilda.cpp">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="225">
-          <caret line="15" selection-start-line="15" selection-end-line="15" />
-          <folding>
-            <element signature="e#0#18#0" expanded="true" />
-          </folding>
+        <state>
+          <caret column="18" selection-start-column="18" selection-end-column="18" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/StringObject.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="105">
+          <caret line="7" column="18" selection-start-line="7" selection-start-column="18" selection-end-line="7" selection-end-column="18" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/Object.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="240">
+          <caret line="16" column="35" lean-forward="true" selection-start-line="16" selection-start-column="35" selection-end-line="16" selection-end-column="35" />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/h/Matilda.h">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="285">
-          <caret line="19" column="7" selection-start-line="19" selection-start-column="7" selection-end-line="19" selection-end-column="7" />
+        <state>
+          <caret column="2" selection-start-column="2" selection-end-column="2" />
           <folding>
             <element signature="e#83#100#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/src/Object.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="345">
+          <caret line="23" lean-forward="true" selection-start-line="23" selection-end-line="23" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/Compiler.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-120">
+          <caret line="67" column="18" selection-start-line="67" selection-start-column="18" selection-end-line="67" selection-end-column="18" />
+          <folding>
+            <element signature="e#55#71#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/h/VM.h">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-1">
-          <caret line="8" column="28" selection-start-line="8" selection-start-column="28" selection-end-line="8" selection-end-column="28" />
+        <state relative-caret-position="254">
+          <caret line="25" lean-forward="true" selection-start-line="25" selection-end-line="25" />
           <folding>
             <element signature="e#35#53#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/Chunk.cpp">
+    <entry file="file://$PROJECT_DIR$/src/h/Value.h">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1050">
-          <caret line="73" column="79" selection-start-line="73" selection-start-column="79" selection-end-line="73" selection-end-column="79" />
+        <state relative-caret-position="390">
+          <caret line="47" column="42" selection-start-line="47" selection-start-column="42" selection-end-line="47" selection-end-column="42" />
+          <folding>
+            <element signature="e#49#68#0" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/Value.h">
+    <entry file="file://$PROJECT_DIR$/src/Value.cpp">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="419">
-          <caret line="41" column="4" selection-start-line="41" selection-start-column="4" selection-end-line="41" selection-end-column="4" />
+        <state relative-caret-position="255">
+          <caret line="17" column="23" lean-forward="true" selection-start-line="17" selection-start-column="23" selection-end-line="17" selection-end-column="23" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Chunk.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="-121">
+          <caret line="78" column="53" selection-start-line="78" selection-start-column="53" selection-end-line="78" selection-end-column="53" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/VM.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="1515">
+          <caret line="101" column="13" selection-start-line="101" selection-start-column="13" selection-end-line="101" selection-end-column="13" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="89">
+          <caret line="103" column="52" selection-start-line="103" selection-start-column="52" selection-end-line="103" selection-end-column="52" />
+          <folding>
+            <element signature="e#0#23#0" expanded="true" />
+          </folding>
         </state>
       </provider>
     </entry>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,4 @@ add_executable(
         src/h/Chunk.h
         src/VM.cpp
         src/h/VM.h
-        src/h/Compiler.h src/Compiler.cpp src/h/Value.h src/Value.cpp)
+        src/h/Compiler.h src/Compiler.cpp src/h/Value.h src/Value.cpp src/h/Object.h src/Object.cpp)

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -91,8 +91,8 @@ void Compiler::binary() {
 bool Compiler::compile() {
     advance();
     expression();
-    consume(TokenType::ENDFILE, "Expected end of expression.");
     emitByte(OpCode::RETURN);
+    consume(TokenType::ENDFILE, "Expected end of expression.");
 
     return !m_hadError;
 }
@@ -103,7 +103,12 @@ void Compiler::errorAt(const Token &token, const std::string &message) {
     if (token.type == TokenType::ENDFILE) {
         std::cerr << " at end: " << message << "\n\n";
     } else {
-        std::cerr << " at '" << token.lexeme << "':\n";
+        if (token.type == TokenType::ERROR) {
+            std::cerr << ":\n";
+        } else {
+            std::cerr << " at '" << token.lexeme << "':\n";
+        }
+
         std::cerr << "    " << m_scanner.getSourceLine(token.line) << "\n";
         for (int i = 1; i < token.col; ++i) {
             std::cerr << " ";

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -52,6 +52,11 @@ void Compiler::literal() {
     }
 }
 
+void Compiler::string() {
+    StringObject *object = new StringObject{m_previous.lexeme.substr(1, m_previous.lexeme.size() - 2)};
+    emitConstant(Value{object});
+}
+
 void Compiler::unary() {
     TokenType operatorType = m_previous.type;
 
@@ -96,7 +101,7 @@ void Compiler::errorAt(const Token &token, const std::string &message) {
     std::cerr << "[line " << token.line << "] Error";
 
     if (token.type == TokenType::ENDFILE) {
-        std::cerr << " at end:";
+        std::cerr << " at end: " << message << "\n\n";
     } else {
         std::cerr << " at '" << token.lexeme << "':\n";
         std::cerr << "    " << m_scanner.getSourceLine(token.line) << "\n";

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -1,0 +1,31 @@
+#include "h/Object.h"
+
+bool Object::operator==(Object &object) {
+    if (this->type != object.type) return false;
+    switch (this->type) {
+        case ObjectType::STRING:
+            return this->asString()->asStdString() == object.asString()->asStdString();
+    }
+}
+
+bool Object::isString() const {
+    return type == ObjectType::STRING;
+}
+
+std::ostream& operator<<(std::ostream &stream, Object &object) {
+    if (object.isString()) stream << object.asString()->asStdString();
+}
+
+StringObject* Object::asString() {
+    return ((StringObject*)this);
+}
+
+StringObject::StringObject(std::string value) : m_str{std::move(value)} {}
+
+StringObject StringObject::operator+(const StringObject &object) const {
+    return StringObject{m_str + object.m_str};
+}
+
+const std::string& StringObject::asStdString() const {
+    return m_str;
+}

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -46,7 +46,10 @@ Token Scanner::scanToken() {
             return string();
     }
 
-    return errorToken("Unrecognized character '" + std::to_string(c) + "'.");
+    std::string errorMessage = "Unrecognized character '";
+    errorMessage.append(std::string{c});
+    errorMessage.append("'.");
+    return errorToken(errorMessage);
 }
 
 void Scanner::skipWhitespace() {
@@ -67,6 +70,7 @@ void Scanner::skipWhitespace() {
             case '/':
                 if (peekNext() == '/') {
                     while (peek() != '\n' && !isAtEnd()) advance();
+                    match('\n');
                 } else {
                     return;
                 }

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -50,7 +50,23 @@ InterpretResult VM::run() {
             }
             case OpCode::GREATER: BINARY_OP(>); break;
             case OpCode::LESS: BINARY_OP(<); break;
-            case OpCode::ADD: BINARY_OP(+); break;
+            case OpCode::ADD: {
+                if (peek(0).isNumber() && peek(1).isNumber()) {
+                    double b = pop().asNumber();
+                    double a = pop().asNumber();
+                    push(Value{a + b});
+                } else if (peek(0).isObject() && peek(1).isObject() &&
+                            peek(0).asObject()->isString() && peek(1).asObject()->isString()) {
+                    StringObject *b = pop().asObject()->asString();
+                    StringObject *a = pop().asObject()->asString();
+                    StringObject *result = new StringObject{*a + *b};
+                    push(Value{result});
+                } else {
+                    runtimeError("Operands must be two numbers or two strings.");
+                    return InterpretResult::RUNTIME_ERROR;
+                }
+                break;
+            }
             case OpCode::SUBTRACT: BINARY_OP(-); break;
             case OpCode::MULTIPLY: BINARY_OP(*); break;
             case OpCode::DIVIDE: BINARY_OP(/); break;
@@ -83,7 +99,12 @@ InterpretResult VM::run() {
 }
 
 void VM::runtimeError(const std::string &message) {
-    std::cout << message << "\n[line " << m_chunk.getLine(m_currentInstruction) << "]\n";
+    std::cerr << message << "\n[line " << m_chunk.getLine(m_currentInstruction) << "]\n";
+    resetStack();
+}
+
+void VM::resetStack() {
+    m_stackTop = 0;
 }
 
 void VM::push(Value value) {

--- a/src/Value.cpp
+++ b/src/Value.cpp
@@ -3,6 +3,7 @@
 Value::Value() : m_type{Type::NIL}, m_as{.number = 0.0} {}
 Value::Value(bool boolean) : m_type{Type::BOOL}, m_as{.boolean = boolean} {}
 Value::Value(double number) : m_type{Type::NUMBER}, m_as{.number = number} {}
+Value::Value(Object *object) : m_type{Type::OBJECT}, m_as{.object = object} {}
 
 bool Value::operator==(Value value) {
     if (value.m_type != this->m_type) return false;
@@ -10,6 +11,7 @@ bool Value::operator==(Value value) {
         case Type::BOOL: return this->asBool() == value.asBool();
         case Type::NIL: return true;
         case Type::NUMBER: return this->asNumber() == value.asNumber();
+        case Type::OBJECT: return *(this->asObject()) == *(value.asObject());
     }
 }
 
@@ -25,12 +27,20 @@ bool Value::isNumber() const {
     return m_type == Type::NUMBER;
 }
 
+bool Value::isObject() const {
+    return m_type == Type::OBJECT;
+}
+
 bool Value::asBool() const {
     return m_as.boolean;
 }
 
 double Value::asNumber() const {
     return m_as.number;
+}
+
+Object* Value::asObject() const {
+    return m_as.object;
 }
 
 bool Value::isFalsey() const {

--- a/src/h/Compiler.h
+++ b/src/h/Compiler.h
@@ -65,6 +65,7 @@ private:
     void grouping();
     void number();
     void literal();
+    void string();
     void unary();
     void binary();
 
@@ -91,7 +92,7 @@ private:
             ParseRule{nullptr,             &Compiler::binary, Precedence::COMPARISON}, // LESS
             ParseRule{nullptr,             &Compiler::binary, Precedence::COMPARISON}, // LESS_EQUAL
             ParseRule{nullptr,             nullptr,           Precedence::NONE}, // IDENTIFIER
-            ParseRule{nullptr,             nullptr,           Precedence::NONE}, // STRING
+            ParseRule{&Compiler::string,   nullptr,           Precedence::NONE}, // STRING
             ParseRule{&Compiler::number,   nullptr,           Precedence::NONE}, // NUMBER
             ParseRule{nullptr,             nullptr,           Precedence::NONE}, // AND
             ParseRule{nullptr,             nullptr,           Precedence::NONE}, // BOOL

--- a/src/h/Object.h
+++ b/src/h/Object.h
@@ -1,0 +1,36 @@
+#ifndef MATILDA_OBJECT_H
+#define MATILDA_OBJECT_H
+
+#include <string>
+
+enum class ObjectType {
+    STRING
+};
+
+class StringObject;
+
+class Object {
+private:
+    ObjectType type;
+    Object *next;
+public:
+    bool operator==(Object &object);
+
+    bool isString() const;
+
+    StringObject* asString();
+
+    friend std::ostream& operator<<(std::ostream &stream, Object &object);
+};
+
+class StringObject : public Object {
+private:
+    std::string m_str;
+public:
+    explicit StringObject(std::string value);
+
+    StringObject operator+(const StringObject &object) const;
+    const std::string& asStdString() const;
+};
+
+#endif //MATILDA_OBJECT_H

--- a/src/h/VM.h
+++ b/src/h/VM.h
@@ -24,6 +24,8 @@ private:
 
     index_t m_currentInstruction;
 
+    void resetStack();
+
     Value peek(int distance) const;
 public:
     explicit VM(const Chunk &chunk);

--- a/src/h/Value.h
+++ b/src/h/Value.h
@@ -3,32 +3,39 @@
 
 #include <iostream>
 
+#include "Object.h"
+
 class Value {
 public:
     enum class Type {
         BOOL,
         NIL,
-        NUMBER
+        NUMBER,
+        OBJECT,
     };
 private:
     Type m_type;
     union {
         bool boolean;
         double number;
+        Object *object;
     } m_as;
 public:
     Value();
     explicit Value(bool boolean);
     explicit Value(double number);
+    explicit Value(Object *object);
 
     bool operator==(Value value);
 
     bool isBool() const;
     bool isNil() const;
     bool isNumber() const;
+    bool isObject() const;
 
     bool asBool() const;
     double asNumber() const;
+    Object* asObject() const;
 
     bool isFalsey() const;
     bool isTruthy() const;
@@ -38,6 +45,7 @@ inline std::ostream& operator<<(std::ostream &stream, const Value &value) {
     if (value.isBool()) stream << (value.asBool() ? "true" : "false");
     else if (value.isNil()) stream << "nil";
     else if (value.isNumber()) stream << value.asNumber();
+    else if (value.isObject()) stream << *value.asObject();
 
     return stream;
 }


### PR DESCRIPTION
This pull request is not related to any issue.

This PR implements string support.

`Value`s may now hold a pointer to an `Object`. `Object`s are the heap-allocated structures in Matilda, and currently the only type is `StringObject`.

`StringObject` uses an `std::string` to allocate the characters. `Object`s leak memory, as there is currently no garbage collector implemented.