### PR TITLE
Clean up expression parsing

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="BookmarkManager">
-    <bookmark url="file://$PROJECT_DIR$/src/Scanner.cpp" line="45" />
-  </component>
   <component name="CMakeRunConfigurationManager" shouldGenerate="true" shouldDeleteObsolete="true">
     <generated>
-      <config projectName="enact" targetName="matilda" />
       <config projectName="enact" targetName="enact" />
+      <config projectName="enact" targetName="matilda" />
     </generated>
   </component>
   <component name="CMakeSettings">
@@ -16,7 +13,21 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="2be96c61-a869-49e1-a6f0-06fa04b9dd52" name="Default Changelist" comment="">
+      <change afterPath="$PROJECT_DIR$/src/ast/generate.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Analyser.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Analyser.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/AstPrinter.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/AstPrinter.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Enact.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Enact.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Parser.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Parser.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Scanner.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/src/Scanner.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/ast/Expr.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/ast/Expr.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/ast/Stmt.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/ast/Stmt.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/Analyser.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Analyser.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/AstPrinter.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/AstPrinter.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/Parser.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Parser.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/Scanner.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Scanner.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/Token.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/Token.h" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/h/common.h" beforeDir="false" afterPath="$PROJECT_DIR$/src/h/common.h" afterDir="false" />
     </list>
     <ignored path="$PROJECT_DIR$/cmake-build-debug/" />
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
@@ -43,40 +54,22 @@
   <component name="FileEditorManager">
     <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/Token.h">
+        <entry file="file://$PROJECT_DIR$/src/h/Parser.h">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="255">
-              <caret line="19" lean-forward="true" selection-start-line="19" selection-end-line="19" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/src/h/common.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="45">
-              <caret line="3" column="16" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
+            <state relative-caret-position="225">
+              <caret line="100" column="64" selection-start-line="100" selection-start-column="64" selection-end-line="100" selection-end-column="64" />
               <folding>
-                <element signature="e#216#225#0" expanded="true" />
+                <element signature="e#47#63#0" expanded="true" />
               </folding>
             </state>
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/Value.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="15">
-              <caret line="1" column="21" selection-start-line="1" selection-start-column="21" selection-end-line="1" selection-end-column="21" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
+      <file pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/src/Parser.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="197">
-              <caret line="110" selection-start-line="110" selection-end-line="110" />
+            <state relative-caret-position="226">
+              <caret line="93" lean-forward="true" selection-start-line="93" selection-end-line="93" />
               <folding>
                 <element signature="e#0#21#0" expanded="true" />
               </folding>
@@ -85,46 +78,10 @@
         </entry>
       </file>
       <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/AstPrinter.cpp">
+        <entry file="file://$PROJECT_DIR$/src/h/Scanner.h">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="272">
-              <caret line="16" column="18" selection-start-line="16" selection-start-column="18" selection-end-line="16" selection-end-column="18" />
-              <folding>
-                <element signature="e#0#18#0" expanded="true" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/Analyser.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="126">
-              <caret line="7" column="61" selection-start-line="7" selection-start-column="61" selection-end-line="7" selection-end-column="61" />
-              <folding>
-                <element signature="e#51#75#0" expanded="true" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/AstPrinter.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="135">
-              <caret line="9" column="68" selection-start-line="9" selection-start-column="68" selection-end-line="9" selection-end-column="68" />
-              <folding>
-                <element signature="e#55#79#0" expanded="true" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/h/Chunk.h">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="15">
-              <caret line="1" column="21" selection-start-line="1" selection-start-column="21" selection-end-line="1" selection-end-column="21" />
+            <state relative-caret-position="211">
+              <caret line="35" column="20" selection-start-line="35" selection-start-column="20" selection-end-line="35" selection-end-column="20" />
             </state>
           </provider>
         </entry>
@@ -132,8 +89,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Scanner.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="390">
-              <caret line="157" selection-start-line="157" selection-end-line="157" />
+            <state relative-caret-position="75">
+              <caret line="83" column="41" selection-start-line="83" selection-start-column="41" selection-end-line="83" selection-end-column="41" />
               <folding>
                 <element signature="e#0#18#0" expanded="true" />
               </folding>
@@ -141,16 +98,14 @@
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/Analyser.cpp">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="152">
-              <caret line="8" column="1" selection-start-line="8" selection-start-column="1" selection-end-line="8" selection-end-column="1" />
-            </state>
-          </provider>
-        </entry>
-      </file>
     </leaf>
+  </component>
+  <component name="FileTemplateManagerImpl">
+    <option name="RECENT_TEMPLATES">
+      <list>
+        <option value="Python Script" />
+      </list>
+    </option>
   </component>
   <component name="FindInProjectRecents">
     <findStrings>
@@ -158,11 +113,14 @@
       <find>m_current</find>
       <find>substr</find>
       <find>[</find>
-      <find>m_last</find>
       <find>m_objects</find>
       <find>class</find>
       <find>std::string</find>
       <find>std::shared_ptr</find>
+      <find>Sp</find>
+      <find>consume</find>
+      <find>match</find>
+      <find>m_last</find>
     </findStrings>
     <replaceStrings>
       <replace>Sp</replace>
@@ -188,7 +146,6 @@
         <option value="$PROJECT_DIR$/src/h/GC.h" />
         <option value="$PROJECT_DIR$/src/GC.cpp" />
         <option value="$PROJECT_DIR$/src/h/Object.h" />
-        <option value="$PROJECT_DIR$/src/h/Scanner.h" />
         <option value="$PROJECT_DIR$/src/h/Matilda.h" />
         <option value="$PROJECT_DIR$/src/Allocator.cpp" />
         <option value="$PROJECT_DIR$/src/h/Allocator.h" />
@@ -208,18 +165,20 @@
         <option value="$PROJECT_DIR$/src/h/Chunk.h" />
         <option value="$PROJECT_DIR$/src/Chunk.cpp" />
         <option value="$PROJECT_DIR$/src/h/Enact.h" />
+        <option value="$PROJECT_DIR$/src/ast/Stmt.h" />
+        <option value="$PROJECT_DIR$/src/h/common.h" />
         <option value="$PROJECT_DIR$/src/ast/Expr.h" />
+        <option value="$PROJECT_DIR$/src/h/Token.h" />
         <option value="$PROJECT_DIR$/src/Enact.cpp" />
-        <option value="$PROJECT_DIR$/src/h/AstPrinter.h" />
+        <option value="$PROJECT_DIR$/src/ast/generate.py" />
         <option value="$PROJECT_DIR$/src/h/Analyser.h" />
         <option value="$PROJECT_DIR$/src/Analyser.cpp" />
-        <option value="$PROJECT_DIR$/src/ast/Stmt.h" />
         <option value="$PROJECT_DIR$/src/AstPrinter.cpp" />
-        <option value="$PROJECT_DIR$/src/h/Parser.h" />
-        <option value="$PROJECT_DIR$/src/h/Token.h" />
-        <option value="$PROJECT_DIR$/src/Parser.cpp" />
+        <option value="$PROJECT_DIR$/src/h/AstPrinter.h" />
+        <option value="$PROJECT_DIR$/src/h/Scanner.h" />
         <option value="$PROJECT_DIR$/src/Scanner.cpp" />
-        <option value="$PROJECT_DIR$/src/h/common.h" />
+        <option value="$PROJECT_DIR$/src/h/Parser.h" />
+        <option value="$PROJECT_DIR$/src/Parser.cpp" />
       </list>
     </option>
   </component>
@@ -234,7 +193,6 @@
       <foldersAlwaysOnTop value="true" />
     </navigator>
     <panes>
-      <pane id="Scope" />
       <pane id="ProjectPane">
         <subPane>
           <expand>
@@ -263,14 +221,19 @@
           <select />
         </subPane>
       </pane>
+      <pane id="Scope" />
     </panes>
   </component>
   <component name="PropertiesComponent">
     <property name="WebServerToolWindowFactoryState" value="false" />
     <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="nodejs_package_manager_path" value="npm" />
     <property name="settings.editor.selected.configurable" value="language.cpp" />
   </component>
   <component name="RecentsManager">
+    <key name="CopyFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/src/ast" />
+    </key>
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/h" />
       <recent name="$PROJECT_DIR$/h" />
@@ -336,12 +299,13 @@
       <workItem from="1543965995288" duration="1401000" />
       <workItem from="1544072125519" duration="2928000" />
       <workItem from="1544246220754" duration="2993000" />
-      <workItem from="1546385606127" duration="7091000" />
+      <workItem from="1546385606127" duration="12523000" />
+      <workItem from="1547105462738" duration="13440000" />
     </task>
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="140198000" />
+    <option name="totallyTimeSpent" value="159070000" />
   </component>
   <component name="TodoView">
     <todo-panel id="selected-file">
@@ -354,14 +318,13 @@
   </component>
   <component name="ToolWindowManager">
     <frame x="67" y="25" width="1853" height="1055" extended-state="6" />
-    <editor active="true" />
     <layout>
-      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.123408966" />
+      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.12451577" />
       <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
       <window_info id="Favorites" order="2" side_tool="true" />
       <window_info anchor="bottom" id="Message" order="0" />
       <window_info anchor="bottom" id="Find" order="1" weight="0.32829374" />
-      <window_info anchor="bottom" id="Run" order="2" visible="true" weight="0.32721382" />
+      <window_info active="true" anchor="bottom" id="Run" order="2" visible="true" weight="0.32721382" />
       <window_info anchor="bottom" id="Debug" order="3" weight="0.39848813" />
       <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
       <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
@@ -378,18 +341,18 @@
       <window_info anchor="right" id="Database" order="3" weight="0.32982844" />
     </layout>
     <layout-to-restore>
-      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.1134477" />
+      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.12451577" />
       <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
       <window_info id="Favorites" order="2" side_tool="true" />
       <window_info anchor="bottom" id="Message" order="0" />
-      <window_info anchor="bottom" id="Find" order="1" weight="0.32972974" />
-      <window_info anchor="bottom" id="Run" order="2" visible="true" weight="0.32829374" />
+      <window_info anchor="bottom" id="Find" order="1" weight="0.32829374" />
+      <window_info anchor="bottom" id="Run" order="2" weight="0.32721382" />
       <window_info anchor="bottom" id="Debug" order="3" weight="0.39848813" />
       <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
       <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
       <window_info anchor="bottom" id="TODO" order="6" />
       <window_info anchor="bottom" id="Database Changes" order="7" show_stripe_button="false" />
-      <window_info anchor="bottom" id="Messages" order="8" weight="0.32721382" />
+      <window_info anchor="bottom" id="Messages" order="8" weight="0.3261339" />
       <window_info anchor="bottom" id="Terminal" order="9" />
       <window_info anchor="bottom" id="Event Log" order="10" side_tool="true" />
       <window_info anchor="bottom" id="Version Control" order="11" show_stripe_button="false" />
@@ -397,62 +360,11 @@
       <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4" />
       <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
       <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
-      <window_info anchor="right" id="Database" order="3" />
+      <window_info anchor="right" id="Database" order="3" weight="0.32982844" />
     </layout-to-restore>
   </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="1" />
-  </component>
-  <component name="XDebuggerManager">
-    <breakpoint-manager>
-      <breakpoints>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>30</line>
-          <option name="timeStamp" value="42" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>15</line>
-          <option name="timeStamp" value="43" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>14</line>
-          <option name="timeStamp" value="44" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>11</line>
-          <option name="timeStamp" value="46" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>12</line>
-          <option name="timeStamp" value="47" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>18</line>
-          <option name="timeStamp" value="50" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>180</line>
-          <option name="timeStamp" value="51" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>181</line>
-          <option name="timeStamp" value="52" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="com.jetbrains.cidr.execution.debugger.OCBreakpointType">
-          <url>file://$PROJECT_DIR$/src/Parser.cpp</url>
-          <line>142</line>
-          <option name="timeStamp" value="54" />
-        </line-breakpoint>
-      </breakpoints>
-    </breakpoint-manager>
   </component>
   <component name="debuggerHistoryManager">
     <expressions id="evaluateExpression">
@@ -504,14 +416,6 @@
     </expressions>
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/h/Object.h" />
-    <entry file="file:///usr/include/c++/7/bits/stl_map.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="198">
-          <caret line="62" selection-start-line="62" selection-end-line="62" />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/h/Matilda.h" />
     <entry file="file://$PROJECT_DIR$/h/Token.h" />
     <entry file="file://$PROJECT_DIR$/h/Compiler.h" />
@@ -548,24 +452,11 @@
     <entry file="file://$PROJECT_DIR$/src/h/Compiler.h" />
     <entry file="file://$PROJECT_DIR$/src/Scope.cpp" />
     <entry file="file://$PROJECT_DIR$/src/h/Scope.h" />
-    <entry file="file://$PROJECT_DIR$/src/Allocator.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="420">
-          <caret line="28" column="35" selection-start-line="28" selection-start-column="35" selection-end-line="28" selection-end-column="35" />
-        </state>
-      </provider>
-    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Allocator.cpp" />
     <entry file="file://$PROJECT_DIR$/src/h/Object.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="525">
           <caret line="35" column="7" selection-start-line="35" selection-start-column="7" selection-end-line="35" selection-end-column="7" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/Scanner.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="780">
-          <caret line="52" column="9" selection-start-line="52" selection-start-column="9" selection-end-line="52" selection-end-column="9" />
         </state>
       </provider>
     </entry>
@@ -600,51 +491,11 @@
     <entry file="file://$PROJECT_DIR$/src/Chunk.cpp">
       <provider selected="true" editor-type-id="text-editor" />
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/Allocator.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="225">
-          <caret line="15" column="26" selection-start-line="15" selection-start-column="26" selection-end-line="15" selection-end-column="26" />
-        </state>
-      </provider>
-    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/Allocator.h" />
     <entry file="file://$PROJECT_DIR$/src/h/Enact.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="195">
           <caret line="14" column="13" selection-start-line="14" selection-start-column="13" selection-end-line="14" selection-end-column="13" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/ast/Expr.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="272">
-          <caret line="41" selection-start-line="41" selection-end-line="44" selection-end-column="5" />
-          <folding>
-            <element signature="e#43#66#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/Parser.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="915">
-          <caret line="133" column="22" selection-start-line="133" selection-start-column="22" selection-end-line="133" selection-end-column="22" />
-          <folding>
-            <element signature="e#47#63#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/ast/Stmt.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="255">
-          <caret line="35" column="2" selection-start-line="35" selection-start-column="2" selection-end-line="35" selection-end-column="2" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Enact.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="915">
-          <caret line="73" column="28" selection-start-line="73" selection-start-column="28" selection-end-line="73" selection-end-column="28" />
         </state>
       </provider>
     </entry>
@@ -655,46 +506,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/AstPrinter.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="272">
-          <caret line="16" column="18" selection-start-line="16" selection-start-column="18" selection-end-line="16" selection-end-column="18" />
-          <folding>
-            <element signature="e#0#18#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Parser.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="197">
-          <caret line="110" selection-start-line="110" selection-end-line="110" />
-          <folding>
-            <element signature="e#0#21#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/Analyser.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="126">
-          <caret line="7" column="61" selection-start-line="7" selection-start-column="61" selection-end-line="7" selection-end-column="61" />
-          <folding>
-            <element signature="e#51#75#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/AstPrinter.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="135">
-          <caret line="9" column="68" selection-start-line="9" selection-start-column="68" selection-end-line="9" selection-end-column="68" />
-          <folding>
-            <element signature="e#55#79#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/h/Chunk.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="15">
@@ -702,36 +513,160 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/Scanner.cpp">
+    <entry file="file://$PROJECT_DIR$/src/ast/decl.cpp">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/decl.h">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="390">
-          <caret line="157" selection-start-line="157" selection-end-line="157" />
+        <state relative-caret-position="135">
+          <caret line="9" column="14" lean-forward="true" selection-start-line="9" selection-start-column="14" selection-end-line="9" selection-end-column="14" />
+          <folding>
+            <element signature="e#42#65#0" expanded="true" />
+            <element signature="e#202#211#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/Decl.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="660">
+          <caret line="47" column="7" selection-start-line="47" selection-start-column="7" selection-end-line="47" selection-end-column="7" />
+          <folding>
+            <element signature="e#120#143#0" expanded="true" />
+            <element signature="e#267#276#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/Txpr.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="500">
+          <caret line="39" column="58" selection-start-line="39" selection-start-column="58" selection-end-line="39" selection-end-column="58" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/Expr.h.old">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/Stmt.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="45">
+          <caret line="3" column="20" selection-start-line="3" selection-start-column="20" selection-end-line="3" selection-end-column="20" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/Stmt.h.old">
+      <provider selected="true" editor-type-id="text-editor" />
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/common.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="120">
+          <caret line="8" column="23" selection-start-line="8" selection-start-column="23" selection-end-line="8" selection-end-column="23" />
+          <folding>
+            <element signature="e#47#65#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/Token.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="135">
+          <caret line="11" column="11" selection-start-line="11" selection-start-column="11" selection-end-line="11" selection-end-column="11" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/Analyser.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="30">
+          <caret line="2" column="2" selection-start-line="2" selection-start-column="2" selection-end-line="2" selection-end-column="2" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Analyser.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="482">
+          <caret line="53" column="2" selection-start-line="53" selection-start-column="2" selection-end-line="53" selection-end-column="2" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Enact.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="150">
+          <caret line="18" column="31" selection-start-line="18" selection-start-column="31" selection-end-line="18" selection-end-column="31" />
+          <caret line="22" column="30" selection-start-line="22" selection-start-column="30" selection-end-line="22" selection-end-column="30" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/generate.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="305">
+          <caret line="67" column="40" lean-forward="true" selection-start-line="67" selection-start-column="40" selection-end-line="67" selection-end-column="40" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ast/Expr.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="79">
+          <caret line="180" column="35" lean-forward="true" selection-start-line="180" selection-start-column="35" selection-end-line="180" selection-end-column="35" />
+          <folding>
+            <element signature="e#413#422#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/AstPrinter.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="332">
+          <caret line="36" column="97" selection-start-line="36" selection-start-column="97" selection-end-line="36" selection-end-column="97" />
           <folding>
             <element signature="e#0#18#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/Analyser.cpp">
+    <entry file="file://$PROJECT_DIR$/src/h/AstPrinter.h">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="152">
-          <caret line="8" column="1" selection-start-line="8" selection-start-column="1" selection-end-line="8" selection-end-column="1" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/Token.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="255">
-          <caret line="19" lean-forward="true" selection-start-line="19" selection-end-line="19" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/h/common.h">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="45">
-          <caret line="3" column="16" selection-start-line="3" selection-start-column="16" selection-end-line="3" selection-end-column="16" />
+        <state relative-caret-position="240">
+          <caret line="16" column="62" selection-start-line="16" selection-start-column="62" selection-end-line="16" selection-end-column="62" />
           <folding>
-            <element signature="e#216#225#0" expanded="true" />
+            <element signature="e#55#79#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/Scanner.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="211">
+          <caret line="35" column="20" selection-start-line="35" selection-start-column="20" selection-end-line="35" selection-end-column="20" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Scanner.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="75">
+          <caret line="83" column="41" selection-start-line="83" selection-start-column="41" selection-end-line="83" selection-end-column="41" />
+          <folding>
+            <element signature="e#0#18#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/h/Parser.h">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="225">
+          <caret line="100" column="64" selection-start-line="100" selection-start-column="64" selection-end-line="100" selection-end-column="64" />
+          <folding>
+            <element signature="e#47#63#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Parser.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="226">
+          <caret line="93" lean-forward="true" selection-start-line="93" selection-end-line="93" />
+          <folding>
+            <element signature="e#0#21#0" expanded="true" />
           </folding>
         </state>
       </provider>

--- a/src/Analyser.cpp
+++ b/src/Analyser.cpp
@@ -1,5 +1,5 @@
 #include "h/Analyser.h"
-
+/*
 void Analyser::analyse(std::vector<Sp<Stmt>> statements) {
 
 }
@@ -51,3 +51,4 @@ void Analyser::visitUnaryExpr(Expr::Unary expr) {
 void Analyser::visitVariableExpr(Expr::Variable expr) {
 
 }
+*/

--- a/src/AstPrinter.cpp
+++ b/src/AstPrinter.cpp
@@ -1,11 +1,11 @@
 #include <sstream>
 #include "h/AstPrinter.h"
 
-void AstPrinter::print(Sp<Stmt> stmt) {
+void AstPrinter::print(std::shared_ptr<Stmt> stmt) {
     std::cout << stmt->accept(this);
 }
 
-std::string AstPrinter::evaluate(Sp<Expr> expr) {
+std::string AstPrinter::evaluate(std::shared_ptr<Expr> expr) {
     return expr->accept(this);
 }
 
@@ -31,6 +31,10 @@ std::string AstPrinter::visitBooleanExpr(Expr::Boolean expr) {
 
 std::string AstPrinter::visitCallExpr(Expr::Call expr) {
     return "(() " + evaluate(expr.callee) + ")";
+}
+
+std::string AstPrinter::visitLogicalExpr(Expr::Logical expr) {
+    return "(" + expr.oper.lexeme + " " + evaluate(expr.left) + " " + evaluate(expr.right) + ")";
 }
 
 std::string AstPrinter::visitNilExpr(Expr::Nil expr) {

--- a/src/Enact.cpp
+++ b/src/Enact.cpp
@@ -16,11 +16,11 @@ void Enact::run(const std::string &source) {
     Parser parser{source};
     //if (!compiler.compile()) return InterpretResult::COMPILE_ERROR;
     //std::cout << compiler.currentChunk().disassemble();
-    std::vector<Sp<Stmt>> statements = parser.parse();
+    std::vector<std::shared_ptr<Stmt>> statements = parser.parse();
     if (parser.hadError()) return;
 
     AstPrinter astPrinter;
-    for (const Sp<Stmt>& stmt : statements) {
+    for (const std::shared_ptr<Stmt>& stmt : statements) {
         astPrinter.print(stmt);
         std::cout << "\n";
     }

--- a/src/ast/Expr.h
+++ b/src/ast/Expr.h
@@ -1,9 +1,10 @@
+// This file was automatically generated.
+// "See generate.py" for details.
+
 #ifndef ENACT_EXPR_H
 #define ENACT_EXPR_H
 
 #include "../h/Token.h"
-#include "../h/Value.h"
-
 #include <memory>
 #include <vector>
 
@@ -13,6 +14,7 @@ public:
     class Binary;
     class Boolean;
     class Call;
+    class Logical;
     class Nil;
     class Number;
     class String;
@@ -27,6 +29,7 @@ public:
         virtual R visitBinaryExpr(Binary expr);
         virtual R visitBooleanExpr(Boolean expr);
         virtual R visitCallExpr(Call expr);
+        virtual R visitLogicalExpr(Logical expr);
         virtual R visitNilExpr(Nil expr);
         virtual R visitNumberExpr(Number expr);
         virtual R visitStringExpr(String expr);
@@ -35,122 +38,193 @@ public:
         virtual R visitVariableExpr(Variable expr);
     };
 
-    virtual void accept(Expr::Visitor<void> *visitor) = 0;
     virtual std::string accept(Expr::Visitor<std::string> *visitor) = 0;
+    virtual void accept(Expr::Visitor<void> *visitor) = 0;
 };
-
-#define EXPR_ACCEPT_FUNCTION(T, name) \
-    T accept(Expr::Visitor<T> *visitor) override { \
-        return visitor->name(*this); \
-    }
 
 class Expr::Assign : public Expr {
 public:
-    Sp<Expr> left, right;
+    std::shared_ptr<Expr> left;
+    std::shared_ptr<Expr> right;
     Token oper;
 
-    Assign(Sp<Expr> left, Sp<Expr> right, Token oper) : left{left}, right{right}, oper{std::move(oper)} {}
+    Assign(std::shared_ptr<Expr> left,std::shared_ptr<Expr> right,Token oper) : 
+        left{left},right{right},oper{oper} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitAssignExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitAssignExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitAssignExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitAssignExpr(*this);
+    }
 };
 
 class Expr::Binary : public Expr {
 public:
-    Sp<Expr> left, right;
+    std::shared_ptr<Expr> left;
+    std::shared_ptr<Expr> right;
     Token oper;
 
-    Binary(Sp<Expr> left, Sp<Expr> right, Token oper) : left{left}, right{right}, oper{std::move(oper)} {}
+    Binary(std::shared_ptr<Expr> left,std::shared_ptr<Expr> right,Token oper) : 
+        left{left},right{right},oper{oper} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitBinaryExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitBinaryExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitBinaryExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitBinaryExpr(*this);
+    }
 };
 
 class Expr::Boolean : public Expr {
 public:
     bool value;
 
-    Boolean(bool value) : value{value} {}
+    Boolean(bool value) : 
+        value{value} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitBooleanExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitBooleanExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitBooleanExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitBooleanExpr(*this);
+    }
 };
 
 class Expr::Call : public Expr {
 public:
-    Sp<Expr> callee;
-    std::vector<Sp<Expr>> arguments;
+    std::shared_ptr<Expr> callee;
+    std::vector<std::shared_ptr<Expr>> arguments;
     Token paren;
 
-    Call(Sp<Expr> callee, std::vector<Sp<Expr>> arguments, Token paren) : callee{callee}, arguments{std::move(arguments)}, paren{std::move(paren)} {}
+    Call(std::shared_ptr<Expr> callee,std::vector<std::shared_ptr<Expr>> arguments,Token paren) : 
+        callee{callee},arguments{arguments},paren{paren} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitCallExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitCallExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitCallExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitCallExpr(*this);
+    }
+};
+
+class Expr::Logical : public Expr {
+public:
+    std::shared_ptr<Expr> left;
+    std::shared_ptr<Expr> right;
+    Token oper;
+
+    Logical(std::shared_ptr<Expr> left,std::shared_ptr<Expr> right,Token oper) : 
+        left{left},right{right},oper{oper} {}
+
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitLogicalExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitLogicalExpr(*this);
+    }
 };
 
 class Expr::Nil : public Expr {
 public:
-    Nil() = default;
+    Nil() {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitNilExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitNilExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitNilExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitNilExpr(*this);
+    }
 };
 
 class Expr::Number : public Expr {
 public:
     double value;
 
-    Number(double value) : value{value} {}
+    Number(double value) : 
+        value{value} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitNumberExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitNumberExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitNumberExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitNumberExpr(*this);
+    }
 };
 
 class Expr::String : public Expr {
 public:
     std::string value;
 
-    String(std::string value) : value{std::move(value)} {}
+    String(std::string value) : 
+        value{value} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitStringExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitStringExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitStringExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitStringExpr(*this);
+    }
 };
-
 
 class Expr::Ternary : public Expr {
 public:
-    Sp<Expr> condition;
-    Sp<Expr> thenExpr;
-    Sp<Expr> elseExpr;
+    std::shared_ptr<Expr> condition;
+    std::shared_ptr<Expr> thenExpr;
+    std::shared_ptr<Expr> elseExpr;
     Token oper;
 
-    Ternary(Sp<Expr> condition, Sp<Expr> thenExpr, Sp<Expr> elseExpr, Token oper) : condition{condition}, thenExpr{thenExpr}, elseExpr{elseExpr}, oper{std::move(oper)} {}
+    Ternary(std::shared_ptr<Expr> condition,std::shared_ptr<Expr> thenExpr,std::shared_ptr<Expr> elseExpr,Token oper) : 
+        condition{condition},thenExpr{thenExpr},elseExpr{elseExpr},oper{oper} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitTernaryExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitTernaryExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitTernaryExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitTernaryExpr(*this);
+    }
 };
 
 class Expr::Unary : public Expr {
 public:
-    Sp<Expr> operand;
+    std::shared_ptr<Expr> operand;
     Token oper;
 
-    Unary(Sp<Expr> operand, Token oper) : operand{operand}, oper{std::move(oper)} {}
+    Unary(std::shared_ptr<Expr> operand,Token oper) : 
+        operand{operand},oper{oper} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitUnaryExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitUnaryExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitUnaryExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitUnaryExpr(*this);
+    }
 };
 
 class Expr::Variable : public Expr {
 public:
     Token name;
 
-    explicit Variable(Token name) : name{std::move(name)} {}
+    Variable(Token name) : 
+        name{name} {}
 
-    EXPR_ACCEPT_FUNCTION(void, visitVariableExpr);
-    EXPR_ACCEPT_FUNCTION(std::string, visitVariableExpr);
+    std::string accept(Expr::Visitor<std::string> *visitor) override {
+        return visitor->visitVariableExpr(*this);
+    }
+
+    void accept(Expr::Visitor<void> *visitor) override {
+        return visitor->visitVariableExpr(*this);
+    }
 };
 
-#undef EXPR_ACCEPT_FUNCTION
-
-#endif //ENACT_EXPR_H
+#endif // ENACT_EXPR_H

--- a/src/ast/Stmt.h
+++ b/src/ast/Stmt.h
@@ -1,3 +1,6 @@
+// This file was automatically generated.
+// "See generate.py" for details.
+
 #ifndef ENACT_STMT_H
 #define ENACT_STMT_H
 
@@ -6,7 +9,6 @@
 class Stmt {
 public:
     class Expression;
-    class Print;
     class Variable;
 
     template <class R>
@@ -16,37 +18,42 @@ public:
         virtual R visitVariableStmt(Variable stmt);
     };
 
-    virtual void accept(Stmt::Visitor<void> *visitor) = 0;
     virtual std::string accept(Stmt::Visitor<std::string> *visitor) = 0;
+    virtual void accept(Stmt::Visitor<void> *visitor) = 0;
 };
-
-#define STMT_ACCEPT_FUNCTION(T, name) \
-    T accept(Stmt::Visitor<T> *visitor) override { \
-        return visitor->name(*this); \
-    }
 
 class Stmt::Expression : public Stmt {
 public:
-    Sp<Expr> expr;
+    std::shared_ptr<Expr> expr;
 
-    Expression(Sp<Expr> expr) : expr{expr} {}
+    Expression(std::shared_ptr<Expr> expr) : 
+        expr{expr} {}
 
-    STMT_ACCEPT_FUNCTION(void, visitExpressionStmt);
-    STMT_ACCEPT_FUNCTION(std::string, visitExpressionStmt);
+    std::string accept(Stmt::Visitor<std::string> *visitor) override {
+        return visitor->visitExpressionStmt(*this);
+    }
+
+    void accept(Stmt::Visitor<void> *visitor) override {
+        return visitor->visitExpressionStmt(*this);
+    }
 };
 
 class Stmt::Variable : public Stmt {
 public:
     Token name;
-    Sp<Expr> initializer;
+    std::shared_ptr<Expr> initializer;
     bool isConst;
 
-    Variable(Token name, Sp<Expr> initializer, bool isConst) : name{std::move(name)}, initializer{initializer}, isConst{isConst} {}
+    Variable(Token name,std::shared_ptr<Expr> initializer,bool isConst) : 
+        name{name},initializer{initializer},isConst{isConst} {}
 
-    STMT_ACCEPT_FUNCTION(void, visitVariableStmt);
-    STMT_ACCEPT_FUNCTION(std::string, visitVariableStmt);
+    std::string accept(Stmt::Visitor<std::string> *visitor) override {
+        return visitor->visitVariableStmt(*this);
+    }
+
+    void accept(Stmt::Visitor<void> *visitor) override {
+        return visitor->visitVariableStmt(*this);
+    }
 };
 
-#undef STMT_ACCEPT_FUNCTION
-
-#endif //ENACT_STMT_H
+#endif // ENACT_STMT_H

--- a/src/ast/generate.py
+++ b/src/ast/generate.py
@@ -1,0 +1,98 @@
+# This script generates the AST classes found in Expr.h/cpp and Stmt.h/cpp.
+
+uncapitalize = lambda s: s[:1].lower() + s[1:] if s else ''
+
+def generate_ast_class_visitors(name, type_fields, visitor_types):
+    ret = "    template <class R>\n    class Visitor {\n    public:\n"
+    for key in type_fields:
+        ret += f"        virtual R visit{key+name}({key} {uncapitalize(name)});\n"
+    ret += "    };\n\n"
+    for type in visitor_types:
+        ret += f"    virtual {type} accept({name}::Visitor<{type}> *visitor) = 0;\n"
+    return ret
+
+def generate_ast_subclasses(name, type_fields, vistor_types):
+    ret = ""
+    for key in type_fields:
+        ret += f"class {name}::{key} : public {name} {{\npublic:\n"
+        if len(type_fields[key]) > 0:
+            for field in type_fields[key]:
+                ret += "    " + field + ";\n"
+            ret += f"\n    {key}("
+            for field in type_fields[key]:
+                ret += field + ","
+            ret = ret[:len(ret)-1]
+            ret += ") : \n        "
+            for field in type_fields[key]:
+                ret += f"{field.split(' ')[1]}{{{field.split(' ')[1]}}},"
+            ret = ret[:len(ret)-1]
+            ret += " {}\n"
+        else:
+            ret += f"    {key}() {{}}\n"
+        for visitor_type in vistor_types:
+            ret += f"\n    {visitor_type} accept({name}::Visitor<{visitor_type}> *visitor) override {{\n        return visitor->visit{key+name}(*this);\n    }}\n"
+        ret += "};\n\n"
+    return ret
+
+def generate_ast_class_body(name, type_fields, visitor_types):
+    ret = ""
+    for key in type_fields:
+        ret += f"    class {key};\n"
+    ret += "\n" + generate_ast_class_visitors(name, type_fields, visitor_types)
+    ret += "};\n\n"
+    return ret
+
+def generate_includes(includes):
+    ret = ""
+    for include in includes:
+        ret += f"#include {include}\n"
+    return ret
+
+def generate_ast_class(name, type_fields, visitor_types, includes):
+    ret = ("// This file was automatically generated.\n"
+           "// \"See generate.py\" for details.\n\n"
+           f"#ifndef ENACT_{name.upper()}_H\n"
+           f"#define ENACT_{name.upper()}_H\n\n"
+
+           f"{generate_includes(includes)}\n"
+           
+           f"class {name} {{\n"
+           "public:\n"
+           f"{generate_ast_class_body(name, type_fields, visitor_types)}"
+           f"{generate_ast_subclasses(name, type_fields, visitor_types)}"
+           f"#endif // ENACT_{name.upper()}_H\n"
+           )
+    return ret
+
+def generate_tree(name, type_fields, visitor_types, includes):
+    with open(name + ".h", "w") as file:
+        file.write(generate_ast_class(name, type_fields, visitor_types, includes))
+
+generate_tree(
+    "Expr",
+    {
+        "Assign"    : ["std::shared_ptr<Expr> left", "std::shared_ptr<Expr> right", "Token oper"],
+        "Binary"    : ["std::shared_ptr<Expr> left", "std::shared_ptr<Expr> right", "Token oper"],
+        "Boolean"   : ["bool value"],
+        "Call"      : ["std::shared_ptr<Expr> callee", "std::vector<std::shared_ptr<Expr>> arguments", "Token paren"],
+        "Logical"   : ["std::shared_ptr<Expr> left", "std::shared_ptr<Expr> right", "Token oper"],
+        "Nil"       : [],
+        "Number"    : ["double value"],
+        "String"    : ["std::string value"],
+        "Ternary"   : ["std::shared_ptr<Expr> condition", "std::shared_ptr<Expr> thenExpr", "std::shared_ptr<Expr> elseExpr", "Token oper"],
+        "Unary"     : ["std::shared_ptr<Expr> operand", "Token oper"],
+        "Variable"  : ["Token name"]
+    },
+    ["std::string", "void"],
+    ['"../h/Token.h"', "<memory>", "<vector>"]
+)
+
+generate_tree(
+    "Stmt",
+    {
+        "Expression" : ["std::shared_ptr<Expr> expr"],
+        "Variable" : ["Token name", "std::shared_ptr<Expr> initializer", "bool isConst"],
+    },
+    ["std::string", "void"],
+    ['"Expr.h"']
+)

--- a/src/h/Analyser.h
+++ b/src/h/Analyser.h
@@ -1,6 +1,6 @@
 #ifndef ENACT_ANALYSER_H
 #define ENACT_ANALYSER_H
-
+/*
 #include "../ast/Expr.h"
 #include "../ast/Stmt.h"
 
@@ -21,5 +21,5 @@ class Analyser : private Expr::Visitor<void>, private Stmt::Visitor<void> {
 public:
     void analyse(std::vector<Sp<Stmt>> statements);
 };
-
+*/
 #endif //ENACT_ANALYSER_H

--- a/src/h/AstPrinter.h
+++ b/src/h/AstPrinter.h
@@ -14,6 +14,7 @@ class AstPrinter : private Stmt::Visitor<std::string>, private Expr::Visitor<std
     std::string visitBinaryExpr(Expr::Binary expr) override;
     std::string visitBooleanExpr(Expr::Boolean expr) override;
     std::string visitCallExpr(Expr::Call expr) override;
+    std::string visitLogicalExpr(Expr::Logical expr) override;
     std::string visitNilExpr(Expr::Nil expr) override;
     std::string visitNumberExpr(Expr::Number expr) override;
     std::string visitStringExpr(Expr::String expr) override;
@@ -21,9 +22,9 @@ class AstPrinter : private Stmt::Visitor<std::string>, private Expr::Visitor<std
     std::string visitUnaryExpr(Expr::Unary expr) override;
     std::string visitVariableExpr(Expr::Variable expr) override;
 
-    std::string evaluate(Sp<Expr> expr);
+    std::string evaluate(std::shared_ptr<Expr> expr);
 public:
-    void print(Sp<Stmt> stmt);
+    void print(std::shared_ptr<Stmt> stmt);
 };
 
 #endif //ENACT_ASTPRINTER_H

--- a/src/h/Scanner.h
+++ b/src/h/Scanner.h
@@ -33,6 +33,7 @@ private:
     char advance();
     char peek();
     char peekNext();
+    char previous();
     bool match(char expected);
 
     bool isDigit(char c);
@@ -45,7 +46,7 @@ public:
     std::string getSourceLine(line_t line);
 
     Token scanToken();
-
+    bool consumeSeparator();
 
 };
 

--- a/src/h/Token.h
+++ b/src/h/Token.h
@@ -9,7 +9,7 @@ enum class TokenType {
     // Single character tokens.
     LEFT_PAREN, RIGHT_PAREN,
     LEFT_SQUARE, RIGHT_SQUARE,
-    COMMA, DOT, MINUS, PLUS,
+    COLON, COMMA, DOT, MINUS, PLUS,
     QUESTION, SEMICOLON, SLASH, STAR,
 
     // 1 or 2 character tokens.
@@ -17,9 +17,6 @@ enum class TokenType {
     EQUAL, EQUAL_EQUAL,
     GREATER, GREATER_EQUAL,
     LESS, LESS_EQUAL,
-
-    // 1 or 2 or 3 character tokens
-    COLON, COLON_EQUAL, COLON_COLON_EQUAL,
 
     // Literals.
     IDENTIFIER, STRING, NUMBER,

--- a/src/h/common.h
+++ b/src/h/common.h
@@ -8,10 +8,4 @@ typedef int index_t;
 typedef uint32_t line_t;
 typedef uint16_t col_t;
 
-template <class T>
-using Sp = std::shared_ptr<T>;
-
-template <class T>
-using Up = std::unique_ptr<T>;
-
 #endif //ENACT_COMMON_H


### PR DESCRIPTION
**Related issue:** #21

**Changes made** \
Cleans up the existing expression parser to properly support precedence and associativity. Added a unique AST node for logical binary operators.