### PR TITLE
Add compilation support for logical operators

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -52,7 +52,7 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Analyser.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="166">
+            <state relative-caret-position="6859">
               <caret line="361" selection-start-line="361" selection-end-line="361" />
               <folding>
                 <element signature="e#0#17#0" expanded="true" />
@@ -61,11 +61,11 @@
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="false">
+      <file pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/src/VM.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="479">
-              <caret line="81" column="13" lean-forward="true" selection-start-line="81" selection-start-column="13" selection-end-line="81" selection-end-column="13" />
+            <state relative-caret-position="346">
+              <caret line="104" column="20" selection-start-line="104" selection-start-column="20" selection-end-line="104" selection-end-column="20" />
               <folding>
                 <element signature="e#0#17#0" expanded="true" />
               </folding>
@@ -88,8 +88,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/h/Chunk.h">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="133">
-              <caret line="16" column="15" selection-start-line="16" selection-start-column="15" selection-end-line="16" selection-end-column="15" />
+            <state relative-caret-position="437">
+              <caret line="32" column="17" selection-start-line="32" selection-start-column="17" selection-end-line="32" selection-end-column="17" />
               <folding>
                 <element signature="e#45#62#0" expanded="true" />
               </folding>
@@ -100,8 +100,8 @@
       <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Chunk.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="175">
-              <caret line="267" column="53" selection-start-line="267" selection-start-column="53" selection-end-line="267" selection-end-column="53" />
+            <state relative-caret-position="156">
+              <caret line="107" column="34" selection-start-line="107" selection-start-column="34" selection-end-line="107" selection-end-column="34" />
               <folding>
                 <element signature="e#0#18#0" expanded="true" />
               </folding>
@@ -109,11 +109,11 @@
           </provider>
         </entry>
       </file>
-      <file pinned="false" current-in-tab="true">
+      <file pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="247">
-              <caret line="67" column="28" selection-start-line="67" selection-start-column="28" selection-end-line="67" selection-end-column="28" />
+            <state relative-caret-position="460">
+              <caret line="211" column="16" selection-start-line="211" selection-start-column="16" selection-end-line="211" selection-end-column="16" />
               <folding>
                 <element signature="e#0#23#0" expanded="true" />
               </folding>
@@ -268,10 +268,10 @@
         <option value="$PROJECT_DIR$/src/Analyser.cpp" />
         <option value="$PROJECT_DIR$/src/h/Analyser.h" />
         <option value="$PROJECT_DIR$/src/h/Compiler.h" />
+        <option value="$PROJECT_DIR$/src/Compiler.cpp" />
         <option value="$PROJECT_DIR$/src/h/Chunk.h" />
         <option value="$PROJECT_DIR$/src/Chunk.cpp" />
         <option value="$PROJECT_DIR$/src/VM.cpp" />
-        <option value="$PROJECT_DIR$/src/Compiler.cpp" />
       </list>
     </option>
   </component>
@@ -444,7 +444,7 @@
     <servers />
   </component>
   <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="394309000" />
+    <option name="totallyTimeSpent" value="395659000" />
   </component>
   <component name="TodoView">
     <todo-panel id="selected-file">
@@ -818,32 +818,12 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/Enact.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="688">
-          <caret line="98" column="45" selection-start-line="98" selection-start-column="45" selection-end-line="98" selection-end-column="45" />
-          <folding>
-            <element signature="e#0#18#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/h/Compiler.h">
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="190">
           <caret line="67" column="44" selection-start-line="67" selection-start-column="44" selection-end-line="67" selection-end-column="44" />
           <folding>
             <element signature="e#51#75#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Analyser.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="166">
-          <caret line="361" selection-start-line="361" selection-end-line="361" />
-          <folding>
-            <element signature="e#0#17#0" expanded="true" />
           </folding>
         </state>
       </provider>
@@ -858,20 +838,50 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/src/Analyser.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="6859">
+          <caret line="361" selection-start-line="361" selection-end-line="361" />
+          <folding>
+            <element signature="e#0#17#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Enact.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="688">
+          <caret line="98" column="45" selection-start-line="98" selection-start-column="45" selection-end-line="98" selection-end-column="45" />
+          <folding>
+            <element signature="e#0#18#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/h/Chunk.h">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="133">
-          <caret line="16" column="15" selection-start-line="16" selection-start-column="15" selection-end-line="16" selection-end-column="15" />
+        <state relative-caret-position="437">
+          <caret line="32" column="17" selection-start-line="32" selection-start-column="17" selection-end-line="32" selection-end-column="17" />
           <folding>
             <element signature="e#45#62#0" expanded="true" />
           </folding>
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="460">
+          <caret line="211" column="16" selection-start-line="211" selection-start-column="16" selection-end-line="211" selection-end-column="16" />
+          <folding>
+            <element signature="e#0#23#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/Chunk.cpp">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="175">
-          <caret line="267" column="53" selection-start-line="267" selection-start-column="53" selection-end-line="267" selection-end-column="53" />
+        <state relative-caret-position="156">
+          <caret line="107" column="34" selection-start-line="107" selection-start-column="34" selection-end-line="107" selection-end-column="34" />
           <folding>
             <element signature="e#0#18#0" expanded="true" />
           </folding>
@@ -880,20 +890,10 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/src/VM.cpp">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="479">
-          <caret line="81" column="13" lean-forward="true" selection-start-line="81" selection-start-column="13" selection-end-line="81" selection-end-column="13" />
+        <state relative-caret-position="346">
+          <caret line="104" column="20" selection-start-line="104" selection-start-column="20" selection-end-line="104" selection-end-column="20" />
           <folding>
             <element signature="e#0#17#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Compiler.cpp">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="247">
-          <caret line="67" column="28" selection-start-line="67" selection-start-column="28" selection-end-line="67" selection-end-column="28" />
-          <folding>
-            <element signature="e#0#23#0" expanded="true" />
           </folding>
         </state>
       </provider>

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -105,6 +105,7 @@ std::pair<std::string, size_t> Chunk::disassembleInstruction(size_t index) const
 
         // Short instructions
         case OpCode::JUMP:
+        case OpCode::JUMP_IF_TRUE:
         case OpCode::JUMP_IF_FALSE: {
             std::string str;
             std::tie(str, index) = disassembleShort(index);
@@ -276,6 +277,7 @@ std::string opCodeToString(OpCode code) {
         case OpCode::SET_VARIABLE: return "SET_VARIABLE";
         case OpCode::SET_VARIABLE_LONG: return "SET_VARIABLE_LONG";
         case OpCode::JUMP: return "JUMP";
+        case OpCode::JUMP_IF_TRUE: return "JUMP_IF_TRUE";
         case OpCode::JUMP_IF_FALSE: return "JUMP_IF_FALSE";
         case OpCode::RETURN: return "RETURN";
         // Unreachable.

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -196,7 +196,22 @@ void Compiler::visitIntegerExpr(IntegerExpr &expr) {
 }
 
 void Compiler::visitLogicalExpr(LogicalExpr &expr) {
-    throw errorAt(expr.oper, "Not implemented.");
+    // Always compile the left operand
+    compile(expr.left);
+
+    size_t jumpIndex = 0;
+
+    if (expr.oper.type == TokenType::OR) {
+        jumpIndex = emitJump(OpCode::JUMP_IF_TRUE);
+    } else if (expr.oper.type == TokenType::AND) {
+        jumpIndex = emitJump(OpCode::JUMP_IF_FALSE);
+    }
+
+    emitByte(OpCode::POP);
+
+    compile(expr.right);
+
+    patchJump(jumpIndex, expr.oper);
 }
 
 void Compiler::visitNilExpr(NilExpr &expr) {

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -55,7 +55,7 @@ InterpretResult VM::run(const Chunk& chunk) {
             }
 
             case OpCode::TRUE: push(Value{true}); break;
-            case OpCode::FALSE: push(Value{}); break;
+            case OpCode::FALSE: push(Value{false}); break;
             case OpCode::NIL: push(Value{}); break;
 
             case OpCode::CHECK_NUMERIC: {
@@ -98,6 +98,14 @@ InterpretResult VM::run(const Chunk& chunk) {
                 uint16_t jumpSize = READ_SHORT();
                 index += jumpSize;
                 ip += jumpSize;
+                break;
+            }
+            case OpCode::JUMP_IF_TRUE: {
+                uint16_t jumpSize = READ_SHORT();
+                if (peek(0).asBool()) {
+                    index += jumpSize;
+                    ip += jumpSize;
+                }
                 break;
             }
             case OpCode::JUMP_IF_FALSE: {

--- a/src/h/Chunk.h
+++ b/src/h/Chunk.h
@@ -30,6 +30,7 @@ enum class OpCode : uint8_t {
     SET_VARIABLE_LONG,
 
     JUMP,
+    JUMP_IF_TRUE,
     JUMP_IF_FALSE,
 
     RETURN,


### PR DESCRIPTION
**Related issue:** #39 

**Changes made** \
Added compilation and VM support for the `and` and `or` logical operators. Added a new opcode, `JUMP_IF_TRUE`, to implement `or` efficiently. Fixed a bug where `false` would evaluate to `nil`.
