### PR TITLE
Implement change in for loop syntax

### DIFF
--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -121,7 +121,7 @@ void Compiler::visitForStmt(ForStmt &stmt) {
 
     // Pop the condition
     emitByte(OpCode::POP);
-    
+
     endScope();
 }
 

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -110,9 +110,7 @@ void Compiler::visitForStmt(ForStmt &stmt) {
     endScope();
 
     compile(*stmt.increment);
-    endScope();
 
-    // Pop the increment
     emitByte(OpCode::POP);
 
     emitLoop(loopStartIndex, stmt.keyword);
@@ -120,6 +118,7 @@ void Compiler::visitForStmt(ForStmt &stmt) {
     patchJump(exitJumpIndex, stmt.keyword);
 
     emitByte(OpCode::POP);
+    endScope();
 }
 
 void Compiler::visitFunctionStmt(FunctionStmt &stmt) {

--- a/src/Compiler.cpp
+++ b/src/Compiler.cpp
@@ -101,6 +101,7 @@ void Compiler::visitForStmt(ForStmt &stmt) {
 
     size_t exitJumpIndex = emitJump(OpCode::JUMP_IF_FALSE);
 
+    // Pop the condition
     emitByte(OpCode::POP);
 
     beginScope();
@@ -111,13 +112,16 @@ void Compiler::visitForStmt(ForStmt &stmt) {
 
     compile(*stmt.increment);
 
+    // Pop the increment
     emitByte(OpCode::POP);
 
     emitLoop(loopStartIndex, stmt.keyword);
 
     patchJump(exitJumpIndex, stmt.keyword);
 
+    // Pop the condition
     emitByte(OpCode::POP);
+    
     endScope();
 }
 

--- a/src/Scanner.cpp
+++ b/src/Scanner.cpp
@@ -29,6 +29,7 @@ Token Scanner::scanToken() {
         case '+': return makeToken(TokenType::PLUS);
         case '?': return makeToken(TokenType::QUESTION);
         case ';': return makeToken(TokenType::SEMICOLON);
+        case '|': return makeToken(TokenType::SEPARATOR);
         case '/': return makeToken(TokenType::SLASH);
         case '*': return makeToken(TokenType::STAR);
 

--- a/src/h/Parser.h
+++ b/src/h/Parser.h
@@ -102,6 +102,7 @@ private:
             ParseRule{nullptr,               &Parser::binary,  Precedence::TERM}, // PLUS
             ParseRule{nullptr,               &Parser::ternary, Precedence::CONDITIONAL}, // QUESTION
             ParseRule{nullptr,               nullptr,            Precedence::NONE}, // SEMICOLON
+            ParseRule{nullptr,               nullptr,            Precedence::NONE}, // SEPARATOR
             ParseRule{nullptr,               &Parser::binary,  Precedence::FACTOR}, // SLASH
             ParseRule{nullptr,               &Parser::binary,  Precedence::FACTOR}, // STAR
             ParseRule{&Parser::unary,      nullptr,            Precedence::UNARY}, // BANG

--- a/src/h/Parser.h
+++ b/src/h/Parser.h
@@ -154,7 +154,7 @@ private:
     std::unique_ptr<Stmt> functionDeclaration(bool mustParseBody = true);
     std::unique_ptr<Stmt> structDeclaration();
     std::unique_ptr<Stmt> traitDeclaration();
-    std::unique_ptr<Stmt> variableDeclaration(bool isConst);
+    std::unique_ptr<Stmt> variableDeclaration(bool isConst, bool mustExpectSeparator = true);
 
     // Statements
     std::unique_ptr<Stmt> statement();

--- a/src/h/Token.h
+++ b/src/h/Token.h
@@ -11,7 +11,8 @@ enum class TokenType {
     LEFT_SQUARE, RIGHT_SQUARE,
     COLON, COMMA, DOT, MINUS,
     NEWLINE, PLUS, QUESTION,
-    SEMICOLON, SLASH, STAR,
+    SEMICOLON, SEPARATOR, SLASH,
+    STAR,
 
     // 1 or 2 character tokens.
     BANG, BANG_EQUAL,


### PR DESCRIPTION
**Related issue:** Resolves #64 

**Changes made** \
Changes the for loop syntax to use the vertical separator (`|`) instead of the semicolon (`;`) to separate the initializer, condition and increment.
